### PR TITLE
[A0] Standardize repo remote alias and governance docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/workstream-task.md
+++ b/.github/ISSUE_TEMPLATE/workstream-task.md
@@ -1,0 +1,30 @@
+---
+name: Workstream Task
+about: Standard PIT workstream task template
+title: '[WORKSTREAM] Task title'
+labels: ''
+assignees: ''
+---
+
+## Workstream
+- Repository: `awesomelyradical/pit-proto`
+- Branch: `workstream-<letter>/<description>`
+
+## Task Description
+
+## Dependencies
+- Blocks:
+- Blocked by:
+
+## Acceptance Criteria
+- [ ]
+- [ ]
+
+## Validation
+```bash
+# tests/lint commands run for this repo
+```
+
+## Notes
+- Align with PIT platform contracts.
+- Request human approval if governing documents are changed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,42 @@
-## Summary
+# Pull Request
 
-## Risk / blast radius
+## Issue
+Closes #
 
-## Tests
+## Repository Verification
+- Repository: `awesomelyradical/pit-proto`
+- Branch naming: `workstream-<letter>/<description>`
 
-## Notes for reviewers
+## Governance Impact
+- Governing docs changed: yes/no
+- Human approval explicitly requested (if governing docs changed): yes/no
+
+## Spec Drift
+- Any divergence from PIT platform contracts/specs: yes/no
+- If yes, describe and link follow-up issue/ADR:
+
+## Changes
+- 
+- 
+
+## Testing
+```bash
+# Commands used
+```
+
+## Verification Output
+```bash
+# Paste command output
+```
+
+## Checklist
+- [ ] Correct repository (`awesomelyradical/pit-proto`)
+- [ ] Branch naming convention followed
+- [ ] Tests/lint/format checks pass
+- [ ] Docs updated if behavior changed
+- [ ] No generated protobuf code committed (except in `pit-proto`)
+- [ ] Governing doc changes explicitly request human approval
+
+## Risk / Blast Radius
+
+## Notes for Reviewers

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,232 +1,32 @@
-# PIT Platform — AI Agent Contract (Coding Rules)
-
-These rules are non-negotiable unless a PR explicitly says "RFC / ADR required" and includes the approved ADR link.
-
-## 0) Prime Directive
-
-This platform is an event-sourced system with Kafka as the immutable spine. Services must not smuggle business logic via ad-hoc topics, ad-hoc schemas, or out-of-band side effects.
-
-## 1) Non-Negotiables (Hard Rules)
-
-### 1.1 Kafka Payload Rule
-
-All Kafka messages MUST be `pit.envelope.v1.EventEnvelope`.
-
-Consumers MUST reject non-envelope messages (except temporary migration code explicitly marked `MIGRATION_ONLY`).
-
-### 1.2 Envelope Invariants
-
-`EventEnvelope` MUST include:
-
-- `event_id` (globally unique)
-- `ts` (event time)
-- `producer` (service name + version)
-- `topic` (optional but recommended)
-- `key` (canonical key string)
-- `tenant`, `series`, `cell` as separate fields (cell may be empty for series-scoped events)
-- `payload_type` (fully-qualified protobuf message name)
-- `payload` (protobuf bytes)
-- (recommended) `payload_sha256` for audit/attestation friendliness
-
-Consumers MUST validate:
-
-- `key` matches `tenant`/`series`/`cell` fields (no cross-tenant leakage)
-- `payload_type` matches the message expected for the topic/domain
-
-### 1.3 Keying Rule (Scale Primitive)
-
-PITs scale by key, not by topic.
-
-Canonical key format:
-
-- Cell-scoped: `t/{tenant}/s/{series}/c/{cell}`
-- Series-scoped: `t/{tenant}/s/{series}`
-- Venue: `venue/{venue}` (only for ops/health domains)
-
-Ordering guarantees are assumed only per key, never globally.
-
-### 1.4 Money Rule
-
-No floats for money outside toy demos.
-
-Production events use integer micros (e.g., `int64` micros, `ccy`).
-
-Toy vertical-slice code may use floats only under `cmd/` and must be clearly labeled.
-
-### 1.5 Delivery Semantics
-
-Assume at-least-once. Every consumer must be idempotent.
-
-Offsets are committed only after downstream side effects succeed (produce/write/store).
-
-### 1.6 No Generated Code Committed
-
-Do not commit generated protobuf output (`gen/**`).
-
-Generated artifacts come from pit-proto releases (Go module, Python wheel, Rust crate).
-
-If you see committed generated code, remove it and fix the build to pull artifacts instead.
-
-## 2) Repo Boundaries (What Gets Edited Where)
-
-### 2.1 pit-proto is Authoritative
-
-All `.proto` live in the pit-proto repo.
-
-Schema changes happen there, with:
-
-- `buf lint`
-- `buf breaking` (against main)
-- version bump + release of language artifacts
-
-### 2.2 This Repo Consumes Published Artifacts
-
-Services import generated code from published pit-proto artifacts:
-
-- **Go**: module dependency (recommended: `github.com/awesomelyradical/pit-proto/...`)
-- **Python**: wheel/package dependency (recommended: `pit-proto`)
-- **Rust**: crate dependency (recommended: `pit-proto` or `pit-proto-types`)
-
-This repo may keep a pinned Buf module dependency to validate schemas (optional), but it is not the source of truth.
-
-## 3) Topics, Catalog, and Drift Control
-
-### 3.1 Topic Creation/Changes
-
-No new topics without updating:
-
-- `infra/topics.yaml` (catalog/intent)
-- the deploy manifests (K8s topic CRs / Terraform / whatever provisions topics)
-
-Topic naming: `pit.v{N}.{domain}.{event}`
-
-Domain topics only (`exec`/`acct`/`risk`/`policy`/`strategy`/`runtime`/`checkpoint`/`ops`). Never "one topic per PIT".
-
-### 3.2 Retention/Compaction Policy
-
-Immutable audit topics: long retention (or offload), `cleanup.policy=delete`
-
-State topics: `cleanup.policy=compact` or `compact,delete` with explicit retention windows
-
-Never rely on Kafka "auto-create topics".
-
-## 4) Security + Trust Boundaries
-
-### 4.1 Transport
-
-Kafka connections use mutual TLS.
-
-TLS secrets are mounted from Strimzi `KafkaUser` (or equivalent). No embedded certs in images.
-
-### 4.2 Authorization Model (Expected Shape)
-
-Each service uses its own Kafka principal/cert.
-
-Prefer topic-level ACLs + (later) tenant scoping enforced by envelope validation and service logic.
-
-Never bypass envelope validation "because it's internal".
-
-### 4.3 Attestation Readiness
-
-Design events so an external verifier can reproduce decisions:
-
-- stable schemas
-- deterministic checkpoints
-- event ranges/hashes for proofs (later)
-
-## 5) Implementation Patterns
-
-### 5.1 Producers
-
-Must set `event_id`, `ts`, `producer`, `key` fields, and payload fields.
-
-Must include schema/type in the envelope (`payload_type`).
-
-Use idempotent producer configuration when available (Kafka idempotence).
-
-### 5.2 Consumers
-
-Must:
-
-- parse envelope
-- validate invariants
-- decode payload based on `payload_type`
-- apply logic
-- write outputs
-- commit offsets after success
-
-### 5.3 Dedupe / Idempotency
-
-Use `event_id` as the canonical dedupe key.
-
-Preferred: store processed event_ids with TTL (Redis/RocksDB/Postgres) per consumer group.
-
-If a consumer writes to a DB, enforce idempotency via unique constraints on `event_id`.
-
-## 6) Language-Specific Rules
-
-### 6.1 Rust (Hot Path)
-
-Use `rdkafka` with SSL/TLS.
-
-Avoid hidden proto compilation in runtime containers. Prefer pit-proto crate dependency.
-
-Errors: use `anyhow`/`thiserror`. No panics in long-running services.
-
-### 6.2 Go (Control Plane / Accounting)
-
-Prefer `segmentio/kafka-go` with TLS dialer.
-
-Manual commit after side effects.
-
-No float money in production structs; use micros.
-
-### 6.3 Python (Research/Analytics)
-
-OK to be flexible and exploratory, but still obey envelope rules.
-
-Python services should not become production-critical truth sources.
-
-## 7) Workflows (What to Run Locally / in CI)
-
-### 7.1 Schema Changes (in pit-proto Repo)
-
+# PIT Platform - AI Agent Contract (Repo Rules)
+
+## Repository Identity
+- Repository: `awesomelyradical/pit-proto`
+- Local path: `/home/aric/code/pit-project/pit-proto`
+- Role: Authoritative protobuf schema and artifact publishing repository for PIT platform contracts.
+
+## Prime Directive
+This repository is the source of truth for PIT protobuf schemas and generated artifacts.
+
+## Non-Negotiables
+1. All .proto changes happen here.
+2. Buf checks are mandatory for schema changes.
+3. Breaking changes must be prevented or explicitly versioned.
+4. Generated artifacts are expected here when release process requires them.
+5. Service runtime logic belongs in service repos, not this repo.
+
+## Required Validation for Schema Changes
 ```bash
 buf lint
 buf breaking --against '.git#branch=main'
 buf generate
-# publish artifacts (Go module / Python wheel / Rust crate)
 ```
 
-### 7.2 Service Changes (This Repo)
+## Platform Alignment
+When schema changes affect topics/envelope semantics, coordinate updates in:
+- `/home/aric/code/pit-project/pit/pit_platform_docs/PIT_PLATFORM_SPEC.md`
+- `/home/aric/code/pit-project/pit/pit_platform_docs/TOPICS_AND_KEYS.md`
+- implementing service repos
 
-Update dependencies to the new pit-proto release.
-
-Build containers; run a smoke test that produces one event and observes downstream output.
-
-## 8) Examples (Follow These Patterns)
-
-### 8.1 Envelope Key Fields
-
-```
-key: t/demo/s/alpha/c/0001
-tenant: demo
-series: alpha
-cell: 0001
-payload_type: pit.events.v1.TradeFillEvent
-```
-
-### 8.2 "Vertical Slice" Demo Expectations
-
-- `tradefill-producer` emits enveloped `TradeFillEvent` to `pit.v1.exec.trade_fill`
-- `nav-consumer` consumes fills, emits enveloped `NAVUpdateEvent` to `pit.v1.acct.nav_update`
-- `nav-analytics` consumes nav updates and prints/plots
-
-## 9) What Not to Do (Common Failure Modes)
-
-- Don't add a new topic "just for this feature."
-- Don't emit raw protobuf payloads to Kafka (envelope is mandatory).
-- Don't commit generated code.
-- Don't introduce money floats into production messages.
-- Don't commit Kafka offsets before producing/writing outputs.</content>
-<parameter name="filePath">/home/aric/code/pit/.github/copilot-instructions.md
+## Governance
+Changes to governing docs require explicit human approval in PR review.

--- a/AGENT_GUIDANCE_SUMMARY.md
+++ b/AGENT_GUIDANCE_SUMMARY.md
@@ -1,0 +1,18 @@
+# Agent Guidance Summary
+
+Last updated: 2026-02-12
+
+## Repository
+- Name: `pit-proto`
+- Remote alias: `pit-proto`
+- Role: Authoritative protobuf schema and artifact publishing repository for PIT platform contracts.
+
+## Current Baseline
+- Scaffold/governance docs standardized.
+- Repo configured to follow PIT-wide contracts and review policy.
+
+## Next Setup Tasks
+1. Define repo-specific Phase 2/3 work backlog.
+2. Add concrete CI/test commands for this repo's stack.
+3. Add service/library-specific runbooks and ADRs as implementation grows.
+4. Keep governance docs aligned with PIT platform contracts.

--- a/AGENT_QUICKSTART.md
+++ b/AGENT_QUICKSTART.md
@@ -1,0 +1,28 @@
+# Agent Quick Start
+
+Last updated: 2026-02-12
+
+## Pre-flight Checks
+```bash
+cd /home/aric/code/pit-project/pit-proto
+pwd
+# expected: /home/aric/code/pit-project/pit-proto
+
+git remote -v
+# expected remote name: pit-proto
+```
+
+## Read Before Coding
+- `.github/copilot-instructions.md`
+- `CONTRIBUTING.md`
+- Platform contracts in `/home/aric/code/pit-project/pit/pit_platform_docs/`
+
+## Working Rules
+- Use focused branches: `workstream-<letter>/<description>`
+- Keep changes scoped and reviewable
+- Include concrete test/lint output in PR
+- Flag spec drift explicitly if docs and implementation are temporarily misaligned
+
+## Repository Reminder
+- GitHub repo: `awesomelyradical/pit-proto`
+- Role: Authoritative protobuf schema and artifact publishing repository for PIT platform contracts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,23 @@
 # Contributing
 
+## Scope
+Authoritative protobuf schema and artifact publishing repository for PIT platform contracts.
+
 ## Non-negotiables
 - Keep changes small and reviewable.
-- Do not commit generated artifacts unless explicitly called out for this repo.
-- Prefer schema-first and event-driven integration: change protobuf + topics/keys before writing glue.
+- Schema changes require Buf validation and compatibility checks.
+- Generated artifacts may be updated here as part of schema release workflow.
 
-## Local dev
-- Use a Kind cluster for dev unless otherwise specified.
-- Build container images locally, then load them into Kind.
+## Required Commands (Schema Changes)
+```bash
+buf lint
+buf breaking --against '.git#branch=main'
+buf generate
+```
 
-## PR checklist
-- Tests pass.
-- Lint/formatters pass.
-- Docs updated if behavior changed.
-- Any event/topic/schema changes include an ADR.
+## PR Checklist
+- Buf checks pass.
+- Generated artifacts are consistent with updated schemas.
+- Downstream impact is documented (service/library repos).
+- ADR added/updated for contract-level behavior changes.
+- Governing document changes explicitly request human approval.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ PIT Protocol schemas and generated artifacts. Buf-first; publishes language arti
 
 ## Quickstart
 See CONTRIBUTING.md.
+
+## Agent Setup
+- Read `AGENT_QUICKSTART.md` before starting tasks in this repository.


### PR DESCRIPTION
Repository Verification
- Repository: awesomelyradical/pit-proto
- Branch naming: workstream-a/repo-standardization

Summary
Standardize baseline repository governance and agent-operational docs, and align remote naming convention to reduce cross-repo commit mistakes.

Changes
- Rename local git remote alias convention from origin to pit-proto.
- Replace scaffold PR template with PIT-aligned verification/governance template.
- Replace generic/corrupted copilot instructions with repo-specific schema-authoritative guidance.
- Add AGENT_QUICKSTART.md and AGENT_GUIDANCE_SUMMARY.md.
- Add standard issue template at .github/ISSUE_TEMPLATE/workstream-task.md.
- Align CONTRIBUTING.md and README onboarding pointers.

Governance Impact
- Governing docs changed: yes
- Human approval explicitly requested: yes

Spec Drift
- No runtime behavior changes.
- Documentation/process-only baseline standardization.

Testing
- Verified branch and remote alias are correctly set.
- Verified working tree is clean after commit.

Checklist
- [x] Correct repository
- [x] Branch naming convention followed
- [x] Docs/process changes only (no runtime code behavior change)
- [x] Governing doc changes explicitly request human approval
- [x] Ready for review as part of cross-repo standardization wave
